### PR TITLE
fix: fixed annotation restarts query to avoid using  $__interval variable

### DIFF
--- a/dashboard/alertmanager-dashboard.json
+++ b/dashboard/alertmanager-dashboard.json
@@ -46,7 +46,7 @@
       {
         "datasource": "$datasource",
         "enable": true,
-        "expr": "changes(process_start_time_seconds{ instance=~\"$instance\"}[$__interval]) > 0",
+        "expr": "changes(process_start_time_seconds{ instance=~\"$instance\"}[2m]) > 0",
         "hide": false,
         "iconColor": "#bf1b00",
         "name": "Restarts",


### PR DESCRIPTION
Closes #1  

The annotation query used the `$__interval` variable which can be used only in the query editor.
Accidentally there was a bug causing Grafana to always default to `60s` which made it seemingly working. (more info here https://github.com/grafana/grafana/issues/14795)

This bug was fixed in the `6.0.0-beta1` version of Grafana which made the error to show up. 

Also described here https://github.com/grafana/grafana/issues/15168

