### PR TITLE
Fix version and uptime query

### DIFF
--- a/dashboard/alertmanager-dashboard.json
+++ b/dashboard/alertmanager-dashboard.json
@@ -334,7 +334,7 @@
       ],
       "targets": [
         {
-          "expr": "time() - (alertmanager_build_info{instance=~\"$instance\"} * on (instance, cluster) group_left process_start_time_seconds{instance=~\"$instance\"})",
+          "expr": "time() - (alertmanager_build_info{instance=~\"$instance\"} * on (instance, cluster, job) group_left process_start_time_seconds{instance=~\"$instance\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
When alertmanager and prometheus server sharing same instance, panel "Instance versions and up time" ended with error message:
```
found duplicate series for the match group {instance=\"prometheus1\"} on the right hand-side of the operation: [{__name__=\"process_start_time_seconds\", instance=\"prometheus1\", job=\"alertmanager\", monitor=\"master\", sg=\"prom1_prod\"}, {__name__=\"process_start_time_seconds\", instance=\"prometheus1\", job=\"prometheus\", monitor=\"master\", sg=\"prom1_prod\"}];many-to-many matching not allowed: matching labels must be unique on one side
```
Joining also with `job` will solve this issue.